### PR TITLE
fix(agent_chat): use agent id instead of name for addressing (#118)

### DIFF
--- a/focus/agent_chat/src/channel.ts
+++ b/focus/agent_chat/src/channel.ts
@@ -19,7 +19,7 @@ const PLUGIN_ID = "agent_chat";
 function resolveAgentName(cfg: OpenClawConfig): string {
   const agents = cfg.agents?.list ?? [];
   const defaultAgent = agents.find((a) => a.default) ?? agents[0];
-  return defaultAgent?.name ?? defaultAgent?.id ?? "main";
+  return defaultAgent?.id ?? defaultAgent?.name ?? "main";
 }
 
 // Manual meta definition since "agent_chat" is not in the core channel allowlist


### PR DESCRIPTION
resolveAgentName was returning agent name (display) instead of id (addressing). For agent_chat, id is what matters for mentions and message routing. Swaps priority: id ?? name ?? main.