### PR TITLE
fix: use standard PGDATABASE and read from postgres.json in shell-install.sh (Closes #132)

### DIFF
--- a/shell-install.sh
+++ b/shell-install.sh
@@ -1,15 +1,29 @@
 #!/bin/bash
-# human-install.sh - Environment wrapper for humans
+# shell-install.sh - Environment wrapper for humans
 # Sets up shell environment before calling agent-install.sh
 
-# Detect/export environment
+# Load database config from postgres.json if available
+PG_CONFIG="$HOME/.openclaw/postgres.json"
+if [ -f "$PG_CONFIG" ] && command -v jq &>/dev/null; then
+    _pg_val() { jq -r ".$1 // empty" "$PG_CONFIG" 2>/dev/null; }
+    [ -z "${PGHOST:-}" ]     && val=$(_pg_val host)     && [ -n "$val" ] && export PGHOST="$val"
+    [ -z "${PGPORT:-}" ]     && val=$(_pg_val port)     && [ -n "$val" ] && export PGPORT="$val"
+    [ -z "${PGDATABASE:-}" ] && val=$(_pg_val database) && [ -n "$val" ] && export PGDATABASE="$val"
+    [ -z "${PGUSER:-}" ]     && val=$(_pg_val user)     && [ -n "$val" ] && export PGUSER="$val"
+    [ -z "${PGPASSWORD:-}" ] && val=$(_pg_val password) && [ -n "$val" ] && export PGPASSWORD="$val"
+fi
+
+# Set defaults for anything not loaded from config
+export PGHOST="${PGHOST:-localhost}"
+export PGPORT="${PGPORT:-5432}"
 export PGUSER="${PGUSER:-$(whoami)}"
-export POSTGRES_DB="${POSTGRES_DB:-nova_memory}"
+DB_USER_CLEAN="${PGUSER//-/_}"
+export PGDATABASE="${PGDATABASE:-${DB_USER_CLEAN}_memory}"
 export OPENCLAW_WORKSPACE="${OPENCLAW_WORKSPACE:-$HOME/.openclaw/workspace-coder}"
 
 echo "Environment configured:"
 echo "  PGUSER=$PGUSER"
-echo "  POSTGRES_DB=$POSTGRES_DB"
+echo "  PGDATABASE=$PGDATABASE"
 echo "  OPENCLAW_WORKSPACE=$OPENCLAW_WORKSPACE"
 echo ""
 


### PR DESCRIPTION
## Summary
shell-install.sh was using non-standard POSTGRES_DB variable hardcoded to nova_memory. Now uses standard PGDATABASE and reads from ~/.openclaw/postgres.json.

## Changes
- Replaced POSTGRES_DB with PGDATABASE throughout
- Added postgres.json reading via jq (same pattern as agent-install.sh)
- Falls back to ${USER//-/_}_memory if no config exists
- Prints correct resolved database name

## Testing
All tests passed on staging (nova-staging):
- Static: no POSTGRES_DB references, PGDATABASE used
- With postgres.json: reads configured DB name
- Without postgres.json: falls back to username-derived default
- Env override: PGDATABASE takes precedence
- Hyphen conversion: nova-staging → nova_staging_memory

Closes #132