### PR TITLE
fix: source env-loader.sh in shell-install.sh for API key loading (#133)

### DIFF
--- a/shell-install.sh
+++ b/shell-install.sh
@@ -27,5 +27,12 @@ echo "  PGDATABASE=$PGDATABASE"
 echo "  OPENCLAW_WORKSPACE=$OPENCLAW_WORKSPACE"
 echo ""
 
+# Load API keys from openclaw.json if env-loader is available
+ENV_LOADER="$HOME/.openclaw/lib/env-loader.sh"
+if [ -f "$ENV_LOADER" ]; then
+    source "$ENV_LOADER"
+    load_openclaw_env 2>/dev/null || true
+fi
+
 # Call the agent installer
 exec "$(dirname "$0")/agent-install.sh" "$@"


### PR DESCRIPTION
## Summary

`shell-install.sh` loads DB config from `postgres.json` but didn't load API keys from `openclaw.json` before exec'ing `agent-install.sh`. This caused the installer to prompt/fail for `ANTHROPIC_API_KEY` even when the key was already configured in `openclaw.json`.

## Fix

Source `~/.openclaw/lib/env-loader.sh` and call `load_openclaw_env` (defensively) before the `exec agent-install.sh` call. This loads all API keys from `openclaw.json` into the environment, matching the pattern used for DB config loading.

- If env-loader.sh is missing, falls through silently
- If `load_openclaw_env` fails (empty/corrupt file), caught by `|| true`
- `agent-install.sh` jq fallback (lines 462-464) remains as defense-in-depth

## Test Results

9 test cases executed on staging (7 PASS, 1 pre-existing FAIL in agent-install.sh prereq check → filed as #135, 1 partial needing interactive verification).

Core scenarios all pass: happy path, ENV precedence, multi-key loading, graceful degradation on missing config/jq.

Closes #133