### PR TITLE
fix(#151): cd into extension directory before agent_chat build

### DIFF
--- a/agent-install.sh
+++ b/agent-install.sh
@@ -700,6 +700,9 @@ else
     fi
 fi
 
+# Change to extension directory for build (all relative paths below expect this)
+cd "$EXTENSION_TARGET"
+
 # Build TypeScript
 echo ""
 echo "  Building TypeScript..."


### PR DESCRIPTION
Fixes #151. The agent_chat build section was running npm run build from the repo root. Adds cd "$EXTENSION_TARGET" before the build, matching the pattern already used for agent-config-sync.