### PR TITLE
fix(#155): signal gateway to reload config after agents.json update

### DIFF
--- a/focus/agent-config-sync/index.ts
+++ b/focus/agent-config-sync/index.ts
@@ -103,6 +103,8 @@ function createConfigSyncService(api: OpenClawPluginApi) {
       const changed = await syncAgentsConfig(client, outputPath);
       if (changed) {
         log.info(`agent_config_sync: Initial sync wrote ${outputPath}`);
+        log.info("agent_config_sync: Signaling gateway to reload config (SIGUSR1)");
+        process.kill(process.pid, "SIGUSR1");
       } else {
         log.info(`agent_config_sync: Initial sync — config already up to date`);
       }
@@ -121,6 +123,8 @@ function createConfigSyncService(api: OpenClawPluginApi) {
           const changed = await syncAgentsConfig(client, outputPath);
           if (changed) {
             log.info(`agent_config_sync: Config updated → ${outputPath}`);
+            log.info("agent_config_sync: Signaling gateway to reload config (SIGUSR1)");
+            process.kill(process.pid, "SIGUSR1");
           } else {
             log.info("agent_config_sync: Config unchanged after notification");
           }


### PR DESCRIPTION
Fixes #155. Sends SIGUSR1 after writing agents.json to trigger config reload without depending on hot-reload file watcher.