### PR TITLE
fix(#181, #182): db-bootstrap-context hook package.json, HOOK.md format, installer verification

### DIFF
--- a/agent-install.sh
+++ b/agent-install.sh
@@ -353,13 +353,14 @@ verify_database() {
         VERIFICATION_WARNINGS=$((VERIFICATION_WARNINGS + ${#missing_tables[@]}))
     fi
     
-    # Check bootstrap_context tables
-    BOOTSTRAP_TABLES=$(psql -U "$DB_USER" -d "$DB_NAME" -tAc "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_name LIKE 'bootstrap_context%'" | tr -d '[:space:]')
+    # Check agent_bootstrap_context table (canonical bootstrap context)
+    BOOTSTRAP_TABLE=$(psql -U "$DB_USER" -d "$DB_NAME" -tAc "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'agent_bootstrap_context'" | tr -d '[:space:]')
     
-    if [ "$BOOTSTRAP_TABLES" -ge 4 ]; then
-        echo -e "  ${CHECK_MARK} Bootstrap context tables installed ($BOOTSTRAP_TABLES/4)"
+    if [ "$BOOTSTRAP_TABLE" -ge 1 ]; then
+        BOOTSTRAP_ROWS=$(psql -U "$DB_USER" -d "$DB_NAME" -tAc "SELECT COUNT(*) FROM agent_bootstrap_context" | tr -d '[:space:]')
+        echo -e "  ${CHECK_MARK} Bootstrap context table installed ($BOOTSTRAP_ROWS rows)"
     else
-        echo -e "  ${WARNING} Bootstrap context tables incomplete ($BOOTSTRAP_TABLES/4)"
+        echo -e "  ${WARNING} agent_bootstrap_context table not found"
         VERIFICATION_WARNINGS=$((VERIFICATION_WARNINGS + 1))
     fi
     

--- a/focus/bootstrap-context/hook/HOOK.md
+++ b/focus/bootstrap-context/hook/HOOK.md
@@ -1,8 +1,7 @@
 ---
 name: db-bootstrap-context
-version: 1.0.0
-events:
-  - agent:bootstrap
+description: "Loads agent bootstrap context from PostgreSQL database"
+metadata: {"openclaw":{"emoji":"🗄️","events":["agent:bootstrap"]}}
 ---
 
 # Database Bootstrap Context Hook
@@ -17,38 +16,16 @@ Loads agent context from PostgreSQL database instead of filesystem files.
 4. Falls back to static files in `~/.openclaw/bootstrap-fallback/` if database unavailable
 5. Uses emergency minimal context if everything fails
 
-## Database Tables
+## Database Table
 
-- `bootstrap_context_universal` - Context for all agents (AGENTS.md, SOUL.md, etc.)
-- `bootstrap_context_agents` - Per-agent context (SEED_CONTEXT.md, domain knowledge)
-- `bootstrap_context_config` - System configuration
-- `bootstrap_context_audit` - Change audit log
-
-## Management
-
-Update context via SQL functions:
-
-```sql
--- Universal context
-SELECT update_universal_context('AGENTS', $content$...$content$, 'Agent roster', 'newhart');
-
--- Agent-specific context
-SELECT update_agent_context('coder', 'SEED_CONTEXT', $content$...$content$, 'Coder seed', 'newhart');
-
--- List all context
-SELECT * FROM list_all_context();
-```
+- `agent_bootstrap_context` - All bootstrap context (UNIVERSAL, GLOBAL, DOMAIN, AGENT types)
 
 ## Fallback System
 
 Three-tier fallback:
-1. **Database** - Primary source
+1. **Database** - Primary source (via `get_agent_bootstrap()`)
 2. **Static files** - `~/.openclaw/bootstrap-fallback/*.md`
 3. **Emergency context** - Minimal recovery instructions
-
-## Installation
-
-See `../INSTALLATION_SUMMARY.md` for setup instructions.
 
 ## Owner
 

--- a/focus/bootstrap-context/hook/package.json
+++ b/focus/bootstrap-context/hook/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "db-bootstrap-context",
+  "version": "1.0.0",
+  "type": "module"
+}


### PR DESCRIPTION
## Summary
Three fixes to get the db-bootstrap-context hook working:

1. **package.json** — Added `"type": "module"` (required for ESM `import` syntax)
2. **HOOK.md** — Fixed metadata format from bare YAML `events:` to `metadata: {"openclaw":{"events":[...]}}` (matching other working hooks)
3. **Installer verification** — Updated to check `agent_bootstrap_context` table instead of deprecated `bootstrap_context_*` tables

## Files Changed
- `focus/bootstrap-context/hook/package.json` — new file
- `focus/bootstrap-context/hook/HOOK.md` — fixed frontmatter format
- `agent-install.sh` — updated verification query

## Testing
- ✅ TC-1: package.json exists with type: module
- ✅ TC-3: Installer checks agent_bootstrap_context, no deprecated table references

Closes #181, Closes #182